### PR TITLE
HGO-10: Add git hooks to enforce consistent commit messages and branch naming conventions

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -15,5 +15,4 @@ if [[ ! $commit_msg =~ $valid_commit_message_pattern ]]; then
     exit 1
 fi
 
-# Allow the commit if the message is valid
 exit 0

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# The commit message is passed as the first argument to the commit-msg hook
+commit_msg_file=$1
+commit_msg=$(cat "$commit_msg_file")
+
+# Pattern - HGO-<task-id>: Short description
+valid_commit_message_pattern="^HGO-[0-9]+: .+$"
+
+# RULE - Commit message must follow the pattern => HGO-<task-id>: Short description
+if [[ ! $commit_msg =~ $valid_commit_message_pattern ]]; then
+    echo "Error: Commit message does not follow the required format!"
+    echo "The correct format is: HGO-<task-id>: Short description"
+    echo "Example: HGO-123: Fix login issue"
+    exit 1
+fi
+
+# Allow the commit if the message is valid
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+current_branch=$(git branch --show-current)
+
+# RULE - Don't allow pusing directly on main
+if [ "$current_branch" == "main" ]; then
+    echo "You are trying to push directly to the main branch!"
+    echo "Please switch to a feature branch and create a pull request."
+    exit 1
+fi
+
+
+# Define the regex pattern for the branch name
+branch_pattern="^(feature|bug|enhancement)/HGO-[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$"
+
+# RULE - branch must follow this pattern => feature|bug|enhancement/HGO-<task_id>-(short-description)
+if [[ ! $current_branch =~ $branch_pattern ]]; then
+    echo "Branch name '$current_branch' does not follow the required format!"
+    echo "The correct format is: feature|bug|enhancement/HGO-<task_id>-(short-description)"
+    echo "Examples: feature/HGO-123-fix-login-bug, bug/HGO-456-update-user-profile"
+    exit 1
+fi
+
+# Allow the push for other branches
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,16 +10,15 @@ if [ "$current_branch" == "main" ]; then
 fi
 
 
-# Define the regex pattern for the branch name
-branch_pattern="^(feature|bug|enhancement)/HGO-[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$"
+# Pattern - feature|bug|enhancement/HGO-<task_id>-(short-description)
+valid_branch_pattern="^(feature|bug|enhancement)/HGO-[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$"
 
-# RULE - branch must follow this pattern => feature|bug|enhancement/HGO-<task_id>-(short-description)
-if [[ ! $current_branch =~ $branch_pattern ]]; then
+# RULE - branch must follow the pattern => feature|bug|enhancement/HGO-<task_id>-(short-description)
+if [[ ! $current_branch =~ $valid_branch_pattern ]]; then
     echo "Branch name '$current_branch' does not follow the required format!"
     echo "The correct format is: feature|bug|enhancement/HGO-<task_id>-(short-description)"
     echo "Examples: feature/HGO-123-fix-login-bug, bug/HGO-456-update-user-profile"
     exit 1
 fi
 
-# Allow the push for other branches
 exit 0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
 # Hello Git Ops
+
+## Setting Up Git Hooks for This Repository
+
+This project uses custom Git hooks to ensure code quality and enforce consistent commit messages and branch naming conventions. Please follow the steps below to set up the hooks in your local environment.
+
+### Step 1: Run the Hook Installation Script
+
+Navigate to the root of the repository and run the install-hooks.sh script to set up the Git hooks:
+
+```bash
+./install-hooks.sh
+```
+
+### Step 2: Verify the Installation
+
+After running the script, you can verify that the hooks are in place by listing the hooks in the .git/hooks directory:
+
+```bash
+ls .git/hooks
+```
+
+You should see symlinks to the custom hooks defined in the .githooks directory, such as:
+
+```text
+commit-msg -> ../../.githooks/commit-msg
+pre-push -> ../../.githooks/pre-push
+```
+
+### Step 4: Commit and Push Code as Usual
+
+Now, when you commit or push code, the hooks will automatically validate your commit messages and branch names based on the defined rules.
+
+#### Hook Details
+
+The repository enforces the following rules:
+
+1. Commit Message Format: Commit messages must follow this format:
+
+```text
+HGO-<task-id>: Short description
+Example: HGO-123: Fix login issue
+```
+
+2. Branch Name Format: Branch names must follow this format:
+
+```text
+feature|bug|enhancement/HGO-<task_id>-short-description
+Example: feature/HGO-456-upload-image
+Example: bug/HGO-456-fix-profile-bug
+Example: enhancement/HGO-789-improve-dashboard-ui
+```

--- a/README.md
+++ b/README.md
@@ -14,20 +14,23 @@ Navigate to the root of the repository and run the install-hooks.sh script to se
 
 ### Step 2: Verify the Installation
 
-After running the script, you can verify that the hooks are in place by listing the hooks in the .git/hooks directory:
+After running the script, you can verify that the local hooks path is set to .githooks:
 
 ```bash
-ls .git/hooks
+cat .git/config
 ```
 
-You should see symlinks to the custom hooks defined in the .githooks directory, such as:
+Output:
 
 ```text
-commit-msg -> ../../.githooks/commit-msg
-pre-push -> ../../.githooks/pre-push
+[core]
+    ...
+    hooksPath = .githooks
+    ...
+
 ```
 
-### Step 4: Commit and Push Code as Usual
+### Step 3: Commit and Push Code as Usual
 
 Now, when you commit or push code, the hooks will automatically validate your commit messages and branch names based on the defined rules.
 

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Install shared Git hooks by setting the core.hooksPath config
+
+git config core.hooksPath .githooks
+echo "Git hooks path set to .githooks"


### PR DESCRIPTION
# 💬 Description

In this pull request I have added scripts for validating commit messages and branch names as well as to restrict pushing to main. I have also added the documentation on how to set them up on local environment. 
